### PR TITLE
change class construction by introducing a dataset config

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-# Code-Pile
+# Code-Pile 
 
 ![pytest](https://github.com/CarperAI/Code-Pile/actions/workflows/python_starter.yml/badge.svg)
 
-
 This repository contains the processing scripts to scrape/process the code-pile dataset.
+This project is very young, expect breaking changes.
 
 ## Table of Contents
 * Project Description
@@ -18,6 +18,12 @@ The Code-Pile will be released similar to "the pile" as a folder of .jsonl.zst f
 
 ## How to use the Code-Pile
 It's not finished, ask on discord
+
+cli prototype example (subject to change):
+```
+python -m codepile.codepile download config.json
+python -m codepile.codepile process config.json
+```
 
 ## How to Contribute
 Think about the most usefull Code-data for the next generation of textual Code Models. 

--- a/codepile/codepile.py
+++ b/codepile/codepile.py
@@ -1,64 +1,147 @@
 import sys
 import argparse
 from codepile.stackexchange.stackexchange import *
-from codepile.dataset import Dataset
+from codepile.dataset import Dataset, Scraper, Processor
+from functools import reduce
+
+from pydantic import BaseModel, DirectoryPath
+
+import json
+
+# todo
+CODEPILEINFO = DatasetInfo(
+        id='CodePile',
+        description='',
+        data_end=datetime(2022,1,1),
+        data_start=10,
+        size=10,
+        storage_format='.jsonl.zst',
+        #storage_uri='/root',
+        cpu_hours=1,
+        gpu_hours=1,
+        ram_requirements=1,
+        tempfile_requirement=1,
+        source_uri='https://github.com/CarperAI/Code-Pile',
+        dataset_pros='l',
+        dataset_cons='l',
+        languages=[''],
+        coding_languages=[''],
+        modalities=['discussion'],
+        source_license='gpl',
+        source_citation='this',
+        data_owner='me',
+        contributers=['me']
+        )
+
+
+class CodePileScraper(Scraper):
+    def __init__(self, config, dataset_id, *args, **kwargs):
+        self.config = config
+
+    # this should be already jsonl.zst
+    # dataset specific processing should maybe be done to save storage
+    # subparts should maybe just be downloaded/collected
+    # not really scraped anymore
+    def scrape(self, subdatasets) -> RawDataset:
+        uris = []
+        for d in subdatasets:
+            ds = d.download()
+            uris.append(ds.storage_uris)
+
+        return RawDataset(storage_uris=reduce(lambda x,y: x+y, uris))
+
+
+class CodePileProcessor(Processor):
+    def __init__(self, config, *args, **kwargs):
+        self.config = config
+
+    def process(self, subdatasets, *args, **kwargs):
+        for d in subdatasets:
+            d.process()
+
 
 class CodePile(Dataset):
-    def __init__(self, tempdir, target_dir):
+    def __init__(self, config):
+        self.config = config
+        self.scraper = CodePileScraper(self.config, self.id)
+        self.processor = CodePileProcessor(self.config, self.id)
+
         self.subdatasets = []
 
         subsets = [
             StackExchangeDataset
             ]
+        dataset_ids = [] 
         for d in subsets:
-            self.subdatasets.append(d(tempdir, target_dir))
+            # todo, solve this properly 
+            assert d.id not in dataset_ids, 'dataset ids have to be unique'
+            self.subdatasets.append(d(self.config))
 
     def download(self):
-        for d in self.subdatasets:
-            d.scraper.scrape()
+        self.scraper.scrape(self.subdatasets)
 
     def process(self):
-        for d in self.subdatasets:
-            d.processor.process()
+        self.processor.process(self.subdatasets)
 
-    def merge(self):
-        raise NotImplementedError()
+    @property
+    def id(self):
+        return "CodePileDataset"
+
+    @property
+    def info(self):
+        return CODEPILEINFO
+
+
+class Config(BaseModel):
+    raw_data_dir : DirectoryPath
+    output_data_dir : DirectoryPath
+    tmpdir : DirectoryPath
 
 
 def download(args):
-    ds = CodePile(args.tempdir, args.output_dir)
-    ds.download()
+    config = Config.parse_raw(args.config.read())
+    ds = CodePile(config)
+    raw_data = ds.download()
 
 
 def process(args):
-    ds = CodePile(args.tempdir, args.output_dir)
+    config = Config.parse_raw(args.config.read())
+    ds = CodePile(config)
     ds.process()
 
 
-def cli(cli_args, *args, **kwargs):
-    parser = argparse.ArgumentParser('codepile dataset')
+def configure(args):
+    config = Config(
+            raw_data_dir=args.raw_data_dir,
+            output_data_dir=args.output_data_dir,
+            tmpdir=args.tmpdir
+            )
+    print(config.json())
 
-    subparsers = parser.add_subparsers()
+
+def cli(cli_args, *args, **kwargs):
+    parser = argparse.ArgumentParser('codepile dataset tool')
+
+    subparsers = parser.add_subparsers(required=True)
+
+    configurator_parser = subparsers.add_parser('configure')
+    configurator_parser.add_argument('raw_data_dir', type=str)
+    configurator_parser.add_argument('output_data_dir', type=str)
+    configurator_parser.add_argument('tmpdir', type=str)
+    configurator_parser.set_defaults(func=configure)
 
     download_parser = subparsers.add_parser('download')
-    download_parser.add_argument('output_dir', type=str)
-    download_parser.add_argument('tempdir', type=str)
+    download_parser.add_argument('config', type=argparse.FileType('r'))
     download_parser.set_defaults(func=download)
 
     process_parser = subparsers.add_parser('process')
-    process_parser.add_argument('input_dir', type=str)
-    process_parser.add_argument('output_dir', type=str)
-    process_parser.add_argument('tempdir', type=str)
-
+    process_parser.add_argument('config', type=argparse.FileType('r'))
     process_parser.set_defaults(func=process)
+
 
     args = parser.parse_args(cli_args[1:])
     args.func(args)
 
-    if len(cli_args) == 1:
-        parser.print_help()
 
 if __name__ == "__main__":
     cli(sys.argv)
-    
-

--- a/codepile/dataset.py
+++ b/codepile/dataset.py
@@ -1,4 +1,5 @@
 from typing import Union, Optional, TypeAlias, Literal, Any
+import os
 from abc import ABC, abstractmethod
 import uuid
 import pydantic
@@ -8,8 +9,9 @@ from datetime import datetime
 
 MODALITY = Literal['discussion', 'code_review', 'source_code', 'unittest']
 
+# todo, add/remove usefull/less attributes
 class DatasetInfo(BaseModel):
-    identifier: str
+    id: str
     description: str
     # the last time when new information was incorporated into the dataset
     # aka when was the latest sample collected
@@ -53,7 +55,9 @@ class DatasetInfo(BaseModel):
     contributers: list[str]
 
 
+# todo, change this by factoring out scraping and downloading and collecting
 SourceType = Literal['bulk', 'api', 'staticpages', 'dynamicpages']
+
 
 class DatasetSources(BaseModel):
     # stores the urls from where the data can be collected
@@ -66,6 +70,8 @@ class DatasetSources(BaseModel):
 class RawDataset(BaseModel):
     # where the raw dataset files is stored after the scrape
     storage_uris: list[Union[AnyUrl, FileUrl]]
+    # hashes of t
+    storage_hashes: Optional[dict[Union[AnyUrl, FileUrl], str]]
     # possible locks for parallel writing to the storage_uris
     storage_locks: Optional[list[Any]]
     # wether the download is complete
@@ -79,11 +85,11 @@ class RawDataset(BaseModel):
 
 class Scraper(ABC):
     # logic for downloading/scraping the datasets
-    def __init__(self, tempdir, target_dir, *args, **kwargs):
-        self.tempdir = tempdir
-        self.target_dir = target_dir
+    def __init__(self, config, dataset_id: str, *args, **kwargs):
+        self.config = config
+        self.dataset_id = dataset_id
 
-    def scrape(self):
+    def scrape(self) -> RawDataset:
         raise NotImplementedError()
 
 
@@ -91,21 +97,25 @@ class Processor(ABC):
     # logic for processing the datasets
     # filtering out bad data
     # data transformations
-    # if you wanna use kind a workflow, implement it in here
-    def process(self):
+    # if you wanna use a kind of workflow system for speed, implement it in here
+    def __init__(self, config, dataset_id: str, *args, **kwargs):
+        self.config = config
+        self.dataset_id = dataset_id
+
+    def process(self, raw_data: RawDataset, *args, **kwargs):
         raise NotImplementedError()
 
 
 class Analyser(ABC):
     # logic for getting basic statistics of the dataset
-    def analyse(self):
+    def analyse(self, config):
+        self.config = config
         raise NotImplementedError()
 
 
 class Dataset(ABC):
-    def __init__(self, tempdir, target_dir, *args, **kwargs):
-        self.tempdir = tempdir
-        self.target_dir = target_dir
+    def __init__(self, config, *args, **kwargs):
+        self.config = config
 
         self.info : DatasetInfo = None
 
@@ -113,22 +123,38 @@ class Dataset(ABC):
         self.processor = None 
         self.analyser = None
 
-    def download(self, *args, **kwargs):
-        self.scraper.scrape()
+    def download(self, *args, **kwargs) -> RawDataset:
+        self.raw_data = self.scraper.scrape()
+
+        p = os.path.join(self.config.tmpdir, self.info.id)
+        os.makedirs(p, exist_ok=True)
+        with open(os.path.join(p, 'raw_data.json'), 'w') as f:
+            f.write(self.raw_data.json())
+
+        return self.raw_data
 
     def process(self, *args, **kwargs):
-        self.processor.process()
+        p = os.path.join(self.config.tmpdir, self.info.id)
+        with open(os.path.join(p, 'raw_data.json'), 'r') as f:
+            raw_data = RawDataset.parse_raw(f.read())
+
+        self.processor.process(raw_data)
 
     def analyse(self, *args, **kwargs):
         self.analyser.analyse()
 
-    '''
     @property
     @abstractmethod
     def info(self) -> DatasetInfo:
-        if self.info is None:
-            raise NotImplementedError()
         return self.info
-    '''
+
+    @property
+    @abstractmethod
+    def id(self) -> str:
+        # if datasetinfo will be populated later,
+        # hardcode this value for now, but it needs to be unique
+        # to prevent processing conflicts
+        return self.info.id
+
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,5 +9,9 @@ name = "Code-Pile"
 version = "0.0.1"
 dependencies = [
     "pydantic",
-    "internetarchive"
+    "internetarchive",
+    "py7zr",
+    "more_itertools",
+    "pandas",
+    "pyarrow"
 ]


### PR DESCRIPTION
I wasn't happy with passing the same args to every implementation, so moved those into a config where we can easily store options for constructing the datasets.

This also cleaned up the cli a little.
Additionally i added the extraction code for StackExchange.

Not tested yet, but too early for serious testing.
These implementations should still be considered as spikes.

commit msg:
…onfig, add Stackexchange comment, user, post StackExchangeDoc, add 7zip extraction to StackExchangeProcessor

